### PR TITLE
Fixed the error when using vps as RoundTripFilters

### DIFF
--- a/httpproxy/filters/vps/vps.json
+++ b/httpproxy/filters/vps/vps.json
@@ -1,5 +1,5 @@
 {
-	"servers": [
+	"Servers": [
 		{
 			"Url": "https://127.0.0.1:443/",
 			"Username": "test",

--- a/httpproxy/filters/vps/vpsserver.go
+++ b/httpproxy/filters/vps/vpsserver.go
@@ -23,7 +23,7 @@ var (
 	}
 )
 
-type FetchServer struct {
+type Server struct {
 	URL       *url.URL
 	Username  string
 	Password  string
@@ -31,7 +31,7 @@ type FetchServer struct {
 	Transport *http2.Transport
 }
 
-func (f *FetchServer) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+func (f *Server) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	for key, shouldDelete := range reqWriteExcludeHeader {
 		if shouldDelete && req.Header.Get(key) != "" {
 			req.Header.Del(key)
@@ -48,6 +48,6 @@ func (f *FetchServer) RoundTrip(req *http.Request) (resp *http.Response, err err
 	return resp, nil
 }
 
-func (f *FetchServer) Connect(req *http.Request) (conn net.Conn, err error) {
+func (f *Server) Connect(req *http.Request) (conn net.Conn, err error) {
 	return nil, nil
 }


### PR DESCRIPTION
Fixed the error when using vps as RoundTripFilters : can't find any Servers.
Line 120 in file vps.go throws "out of index".
