### PR TITLE
Bug fixed for auth failed

### DIFF
--- a/goproxy-vps.go
+++ b/goproxy-vps.go
@@ -159,6 +159,7 @@ func (h *HTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 					if err := h.SimpleAuth.Authenticate(username, password); err != nil {
 						http.Error(rw, "403 Forbidden", http.StatusForbidden)
+						return
 					}
 				}
 			default:
@@ -334,6 +335,7 @@ func (h *HTTP2Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 					if err := h.SimpleAuth.Authenticate(username, password); err != nil {
 						http.Error(rw, "403 Forbidden", http.StatusForbidden)
+						return
 					}
 				}
 			default:


### PR DESCRIPTION
Bug fixed for auth failed(http: multiple response.WriteHeader calls)

When auth failed, the response always will be return with 403.

We should return immediately if auth failed.