### PR TITLE
tweak br and gzip process

### DIFF
--- a/gae/gae.go
+++ b/gae/gae.go
@@ -94,9 +94,10 @@ func ReadRequest(r io.Reader) (req *http.Request, err error) {
 
 		req.Method = parts[0]
 		req.RequestURI = parts[1]
-		req.Proto = "HTTP/1.1"
-		req.ProtoMajor = 1
-		req.ProtoMinor = 1
+		// not needed
+		//req.Proto = "HTTP/1.1"
+		//req.ProtoMajor = 1
+		//req.ProtoMinor = 1
 
 		if req.URL, err = url.Parse(req.RequestURI); err != nil {
 			return
@@ -162,8 +163,8 @@ func handlerError(c appengine.Context, rw http.ResponseWriter, err error, code i
 	binary.BigEndian.PutUint16(b0, uint16(b.Len()))
 
 	rw.Header().Set("Content-Type", "image/gif")
-	rw.Header().Set("Content-Length", strconv.Itoa(len(b0)+b.Len()))
-	rw.WriteHeader(http.StatusOK)
+	//rw.Header().Set("Content-Length", strconv.Itoa(len(b0)+b.Len()))
+	//rw.WriteHeader(http.StatusOK)
 	rw.Write(b0)
 	rw.Write(b.Bytes())
 }
@@ -225,12 +226,14 @@ func handler(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	deadline := DefaultDeadline
-	if s := params.Get("X-UrlFetch-Deadline"); s != "" {
-		if n, err := strconv.Atoi(s); err == nil {
-			deadline = time.Duration(n) * time.Second
-		}
-	}
+	//deadline := DefaultDeadline
+	//if s := params.Get("X-UrlFetch-Deadline"); s != "" {
+	//	if n, err := strconv.Atoi(s); err == nil {
+	//		deadline = time.Duration(n) * time.Second
+	//	}
+	//}
+	// Context default deadline
+	deadline := 5
 
 	overquotaDelay := DefaultOverquotaDelay
 	if s := params.Get("X-UrlFetch-OverquotaDelay"); s != "" {
@@ -264,7 +267,8 @@ func handler(rw http.ResponseWriter, r *http.Request) {
 	for i := 0; i < 2; i++ {
 		t := &urlfetch.Transport{
 			Context:                       c,
-			Deadline:                      deadline,
+			// useless now, set in Context
+			//Deadline:                      deadline,
 			AllowInvalidServerCertificate: !sslVerify,
 		}
 
@@ -442,8 +446,9 @@ func handler(rw http.ResponseWriter, r *http.Request) {
 		binary.BigEndian.PutUint16(b0, uint16(b.Len()))
 
 		rw.Header().Set("Content-Type", "image/gif")
-		rw.Header().Set("Content-Length", strconv.FormatInt(int64(len(b0)+b.Len())+resp.ContentLength, 10))
-		rw.WriteHeader(http.StatusOK)
+		// we need not set a "Content-Length" header, App Engine will reset it
+		//rw.Header().Set("Content-Length", strconv.FormatInt(int64(len(b0)+b.Len())+resp.ContentLength, 10))
+		//rw.WriteHeader(http.StatusOK)
 		rw.Write(b0)
 		io.Copy(rw, io.MultiReader(&b, resp.Body))
 	}


### PR DESCRIPTION
@Kisesy 
主任，这个是延续你的服务端解压方案。 #1957 
先前说过这个方案近乎完美，现在我大概解决了压缩导致的延迟问题了。
感谢你帮我查找资料，学习果然让人进步。 :smile: 

@phuslu 
我测试了多遍，运行良好，不过感觉体验提升有限（可能就 0.1 秒左右吧），主要还是看 IP。

此修改利用了，App Engine 本身的特性来支持 gzip，是 chunked 传输方式。

现在兼容旧客户端，要使用 chunked gzip，需要修改。
* 先检测代理请求的 `Accept-Encoding`，如果包含 `gzip` 就将 `User-Agent: Mozilla/5.0`、`Accept-Encoding: gzip` 加入承载请求的 header。
* 检测返回承载响应的 header，如果包含 `X-UrlFetch-BHeaders` 就使用 base64 解码，结果是代理响应的 header，否则按原来流程读取 。

另外，`github.com/dsnet/compress/brotli` 导入所需文件并没有加进修改。